### PR TITLE
Remove checks for ghost crafts

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -1,9 +1,18 @@
--- config.lua  (auto-generated)
--- sleepInterval in seconds; items = { { label, threshold, batchSize }, … }
+-- config.lua  (auto-generated)  
+-- sleepInterval: seconds between checks
+-- shuffle: randomize craft order  
+-- requestTimeoutCycles: max cycles before timing out crafts
+-- resolution: terminal size limits (maxWidth, maxHeight)
+-- items: { { label, threshold, batchSize }, … }
 
 return {
-  sleepInterval = 10,
+  sleepInterval = 40,
   shuffle = true,
+  requestTimeoutCycles = 3,  -- Maximum cycles before timing out a craft
+  resolution = {
+    maxWidth = 120,   -- Maximum terminal width
+    maxHeight = 35    -- Maximum terminal height  
+  },
   items = {
     { "Bronze Ingot", 0, 64 },
     { "Crystaltine Dust", 0, 64 },

--- a/craftables.lua
+++ b/craftables.lua
@@ -51,12 +51,21 @@ local function generateConfig()
   -- header
   out:write([[
 -- config.lua  (auto-generated)
--- sleepInterval in seconds; items = { { label, threshold, batchSize }, … }
+-- sleepInterval in seconds; 
+-- shuffle: randomize craft order  
+-- requestTimeoutCycles: max cycles before timing out crafts
+-- resolution: terminal size limits (maxWidth, maxHeight)
+-- items: { { label, threshold, batchSize }, … }
 
 return {
   sleepInterval = 60,
   shuffle = true,
-  items = {
+  requestTimeoutCycles = 3,
+  resolution = {
+    maxWidth = 120,
+    maxHeight = 35
+  },
+  items = { 
 ]])
 
   -- body

--- a/level_maintainer.lua
+++ b/level_maintainer.lua
@@ -126,12 +126,12 @@ if component.isAvailable("gpu") then
     local gpu = component.gpu
     local maxWidth, maxHeight = gpu.maxResolution()
     
-    local targetWidth = math.min(120, maxWidth)
-    local targetHeight = math.min(35, maxHeight)
+    local targetWidth = math.min(cfg.resolution.maxWidth, maxWidth)
+    local targetHeight = math.min(cfg.resolution.maxHeight, maxHeight)
     
     gpu.setResolution(targetWidth, targetHeight)
     term.clear()
-    print(string.format("🖥️  Set resolution to %dx%d (max: %dx%d)", targetWidth, targetHeight, maxWidth, maxHeight))
+    print(string.format("Set resolution to %dx%d (max: %dx%d)", targetWidth, targetHeight, maxWidth, maxHeight))
 end
 
 -- Reload config to ensure we have the latest settings


### PR DESCRIPTION
Spent some more time with the requests API and realized isDone returns nil when the craft fails to start. This saves sooo much effort and allows us to be much more reliable in determining if a craft actually started.

Additionally:
-  added improved configuration for timeoutCycles and resolution
- cleaned up extra call to cleanupCompletedCrafts