### PR TITLE
Cache optimizations

### DIFF
--- a/ae2_helpers.lua
+++ b/ae2_helpers.lua
@@ -166,7 +166,6 @@ function checkAllThresholds()
                 })
             end
         end
-    
     end
     
     return needsCraftingList
@@ -220,7 +219,7 @@ function startCraft(itemName, amount, currentCycle)
 end
 
 function isItemCurrentlyBeingCrafted(itemName)
-        for craftId, craft in pairs(activeCrafts) do
+    for craftId, craft in pairs(activeCrafts) do
         if craft.itemName == itemName then
             return true, craftId
         end

--- a/ae2_helpers.lua
+++ b/ae2_helpers.lua
@@ -1,4 +1,5 @@
 local component = require("component")
+local computer  = require("computer")
 local fs        = require("filesystem")
 
 colors = {
@@ -78,9 +79,33 @@ local craftablesCacheLoaded = false
 
 function ensureCraftablesCache()
     if not craftablesCacheLoaded then
-        craftablesCache = ME.getCraftables()
+        local startTime = computer.uptime()
+        colorPrint(colors.yellow, "🔄 Loading craftables cache...")
+        
+        craftablesCache = {}
+        local cachedCount = 0
+        
+        -- Query each configured item directly from AE2
+        for i, entry in ipairs(cfg.items) do
+            local itemName = entry[1]
+            local queryStart = computer.uptime()
+            
+            local craftablesList = ME.getCraftables({ label = itemName })
+            local queryTime = computer.uptime() - queryStart
+            
+            if craftablesList and #craftablesList > 0 then
+                local craftable = craftablesList[1] -- Take first match
+                craftablesCache[itemName] = craftable
+                cachedCount = cachedCount + 1
+                colorPrint(colors.yellow, string.format("  [%d/%d] ✓ %s (%.3fs)", i, #cfg.items, itemName, queryTime))
+            else
+                colorPrint(colors.red, string.format("  [%d/%d] ❌ %s (%.3fs) - NOT CRAFTABLE", i, #cfg.items, itemName, queryTime))
+            end
+        end
+        
+        local totalTime = computer.uptime() - startTime
         craftablesCacheLoaded = true
-        colorPrint(colors.cyan, "📚 Loaded craftables cache (" .. #craftablesCache .. " items)")
+        colorPrint(colors.green, string.format("📚 Cache loaded: %d/%d items in %.1fs total", cachedCount, #cfg.items, totalTime))
     end
     return craftablesCache
 end
@@ -141,19 +166,19 @@ function checkAllThresholds()
                 })
             end
         end
+    
     end
     
     return needsCraftingList
 end
 
 function findCraftable(itemName)
-    local craftables = ensureCraftablesCache()
+    ensureCraftablesCache()
     
-    for i, craftable in ipairs(craftables) do
+    local craftable = craftablesCache[itemName]
+    if craftable then
         local itemStack = craftable.getItemStack()
-        if itemStack and (itemStack.name == itemName or itemStack.label == itemName) then
-            return craftable, itemStack
-        end
+        return craftable, itemStack
     end
     
     return nil, nil
@@ -162,6 +187,10 @@ end
 
 function startCraft(itemName, amount, currentCycle)    
     local craftable = findCraftable(itemName)
+    if not craftable then
+        return nil, "Item not craftable: " .. itemName
+    end
+    
     local requestTracker = craftable.request(amount)
     
     if not requestTracker then

--- a/level_maintainer.lua
+++ b/level_maintainer.lua
@@ -22,8 +22,6 @@ end
 
 
 function startMaintainer()    
-    event.listen("interrupted", onInterrupt)
-    
     cycles = 0
     running = true
     interruptReceived = false
@@ -133,6 +131,9 @@ if component.isAvailable("gpu") then
     term.clear()
     print(string.format("Set resolution to %dx%d (max: %dx%d)", targetWidth, targetHeight, maxWidth, maxHeight))
 end
+
+
+event.listen("interrupted", onInterrupt)
 
 -- Reload config to ensure we have the latest settings
 reloadConfig()


### PR DESCRIPTION
- Improve performance on large networks by only checking craftables for items in our config and caching only those. 
- Cache is now a hashmap too for O(1) lookup


Tested on a network with 2k craftables and 50 configured items